### PR TITLE
Change “active” status to “in progress” in completion status enum

### DIFF
--- a/migrations/20250224153425-rename-resource-completion-status.js
+++ b/migrations/20250224153425-rename-resource-completion-status.js
@@ -1,0 +1,49 @@
+const COLLECTION_NAME = 'cooperation'
+const COMPLETION_STATUS = {
+  ACTIVE: 'active',
+  IN_PROGRESS: 'in progress'
+}
+const NOT_EMPTY_SECTIONS_FILTER = {
+  sections: { $ne: [] }
+}
+
+module.exports = {
+  async up(db) {
+    await db.collection(COLLECTION_NAME).updateMany(
+      NOT_EMPTY_SECTIONS_FILTER,
+      {
+        $set: {
+          'sections.$[].resources.$[resource].completionStatus': COMPLETION_STATUS.IN_PROGRESS
+        }
+      },
+      {
+        arrayFilters: [
+          {
+            $or: [
+              { 'resource.completionStatus': COMPLETION_STATUS.ACTIVE },
+              { 'resource.completionStatus': { $exists: false } }
+            ]
+          }
+        ]
+      }
+    )
+  },
+
+  async down(db) {
+    await db.collection(COLLECTION_NAME).updateMany(
+      NOT_EMPTY_SECTIONS_FILTER,
+      {
+        $set: {
+          'sections.$[].resources.$[resource].completionStatus': COMPLETION_STATUS.ACTIVE
+        }
+      },
+      {
+        arrayFilters: [
+          {
+            'resource.completionStatus': COMPLETION_STATUS.IN_PROGRESS
+          }
+        ]
+      }
+    )
+  }
+}

--- a/src/consts/validation.js
+++ b/src/consts/validation.js
@@ -46,7 +46,7 @@ const enums = {
   QUIZ_SETTINGS_ENUM: ['view', 'shuffle', 'pointValues', 'scoredResponses', 'correctAnswers'],
   RESOURCE_STATUS_ENUM: ['available', 'finished'],
   RESOURCE_AVAILABILITY_STATUS_ENUM: ['open', 'closed', 'openFrom'],
-  RESOURCE_COMPLETION_STATUS_ENUM: ['active', 'completed'],
+  RESOURCE_COMPLETION_STATUS_ENUM: ['in progress', 'completed'],
   RESOURCES_TYPES_ENUM: ['lesson', 'quiz', 'attachment', 'question']
 }
 

--- a/src/test/migrations/20250224153425-rename-resource-completion-status.spec.js
+++ b/src/test/migrations/20250224153425-rename-resource-completion-status.spec.js
@@ -1,0 +1,63 @@
+const mongoose = require('mongoose')
+const { serverInit, serverCleanup, stopServer } = require('~/test/setup')
+const migration = require('@root/migrations/20250224153425-rename-resource-completion-status')
+
+const COLLECTION_NAME = 'cooperation'
+
+const cooperationWithOutdatedResources = [
+  {
+    sections: [
+      {
+        resources: [{ completionStatus: 'active' }, { name: 'resource1' }]
+      }
+    ]
+  },
+  {
+    sections: [
+      {
+        resources: [{ completionStatus: 'completed' }, { completionStatus: 'active' }]
+      }
+    ]
+  }
+]
+
+describe('20250224153425-rename-resource-completion-status', () => {
+  let server
+  let db
+
+  beforeAll(async () => {
+    ;({ server } = await serverInit())
+    db = mongoose.connection.db
+  })
+
+  afterEach(async () => await serverCleanup())
+
+  afterAll(async () => {
+    await stopServer(server)
+  })
+
+  test('should set completionStatus to "in progress" for resources with "active" or no completionStatus during up migration', async () => {
+    const collection = db.collection(COLLECTION_NAME)
+
+    await collection.insertMany(cooperationWithOutdatedResources)
+
+    await migration.up(db)
+
+    const updatedDocuments = await collection.find().toArray()
+
+    const inProgressCount = updatedDocuments.flatMap((doc) =>
+      doc.sections.flatMap((section) =>
+        section.resources.filter((resource) => resource.completionStatus === 'in progress')
+      )
+    ).length
+
+    const completedCount = updatedDocuments.flatMap((doc) =>
+      doc.sections.flatMap((section) =>
+        section.resources.filter((resource) => resource.completionStatus === 'completed')
+      )
+    ).length
+
+    expect(inProgressCount).toBe(3)
+    expect(completedCount).toBe(1)
+  })
+})

--- a/src/test/migrations/20250224153425-rename-resource-completion-status.spec.js
+++ b/src/test/migrations/20250224153425-rename-resource-completion-status.spec.js
@@ -21,6 +21,16 @@ const cooperationWithOutdatedResources = [
   }
 ]
 
+const cooperationWithUpdatedResources = [
+  {
+    sections: [
+      {
+        resources: [{ completionStatus: 'in progress' }, { completionStatus: 'completed' }]
+      }
+    ]
+  }
+]
+
 describe('20250224153425-rename-resource-completion-status', () => {
   let server
   let db
@@ -58,6 +68,29 @@ describe('20250224153425-rename-resource-completion-status', () => {
     ).length
 
     expect(inProgressCount).toBe(3)
+    expect(completedCount).toBe(1)
+  })
+
+  test('should revert completionStatus to "active" for resources with "in progress" during down migration', async () => {
+    const collection = db.collection(COLLECTION_NAME)
+
+    await collection.insertMany(cooperationWithUpdatedResources)
+
+    await migration.down(db)
+
+    const updatedDocuments = await collection.find().toArray()
+
+    const activeCount = updatedDocuments.flatMap((doc) =>
+      doc.sections.flatMap((section) => section.resources.filter((resource) => resource.completionStatus === 'active'))
+    ).length
+
+    const completedCount = updatedDocuments.flatMap((doc) =>
+      doc.sections.flatMap((section) =>
+        section.resources.filter((resource) => resource.completionStatus === 'completed')
+      )
+    ).length
+
+    expect(activeCount).toBe(1)
     expect(completedCount).toBe(1)
   })
 })


### PR DESCRIPTION
Cooperation resources completion progress enum

Add migration for data with “in progress” status

![Image](https://github.com/user-attachments/assets/cff840a4-7376-46c8-ac49-11bf98c534a9)

![Image](https://github.com/user-attachments/assets/f7f6cd25-5599-4e33-9f38-dcfc90291969)

![Image](https://github.com/user-attachments/assets/64cad003-9b66-4ed9-829e-3722231f5640)