### PR TITLE
Fix resources search trailing backslashes

### DIFF
--- a/src/utils/getRegex.js
+++ b/src/utils/getRegex.js
@@ -1,6 +1,20 @@
-const getRegex = (regex = '') => ({
-  $regex: regex.length > 0 ? regex : '.*',
-  $options: 'i'
-})
+const getRegex = (regex = '') => {
+  if (!regex) {
+    return {
+      $regex: '.*',
+      $options: 'i'
+    }
+  }
+
+  let processedRegex = regex
+  if (regex.endsWith('\\')) {
+    processedRegex = regex + '\\'
+  }
+
+  return {
+    $regex: processedRegex,
+    $options: 'i'
+  }
+}
 
 module.exports = getRegex


### PR DESCRIPTION
Before:

Try to search \

![image](https://github.com/user-attachments/assets/0d119f5b-0566-4f79-bc5c-3a2171049287)
![image](https://github.com/user-attachments/assets/27d695e8-2614-4beb-ae7e-3f4cda61a11c)
![image](https://github.com/user-attachments/assets/0ae5204c-5742-4b2c-b496-da25897c9ca2)
![image](https://github.com/user-attachments/assets/b61c7f79-2044-48a8-80f1-ca9a4b2a578c)


After fix:
![image](https://github.com/user-attachments/assets/f2dc3978-2023-44ec-a2a6-4be3250965ae)

